### PR TITLE
feat(transaction): implement all transaction endpoints

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3,6 +3,9 @@
   "workspaces": {
     "": {
       "name": "@redoxx/paystack",
+      "dependencies": {
+        "axios": "^1.10.0",
+      },
       "devDependencies": {
         "@types/bun": "latest",
         "@typescript-eslint/eslint-plugin": "^8.34.0",
@@ -74,6 +77,10 @@
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "axios": ["axios@1.10.0", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.0", "proxy-from-env": "^1.1.0" } }, "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw=="],
+
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
@@ -81,6 +88,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "bun-types": ["bun-types@1.2.16", "", { "dependencies": { "@types/node": "*" } }, "sha512-ciXLrHV4PXax9vHvUrkvun9VPVGOVwbbbBF/Ev1cXz12lyEZMoJpIJABOfPcN9gDJRaiKF9MVbSygLg4NXu3/A=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -90,6 +99,8 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
@@ -98,7 +109,19 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -138,7 +161,17 @@
 
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
+    "follow-redirects": ["follow-redirects@1.15.9", "", {}, "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="],
+
+    "form-data": ["form-data@4.0.3", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA=="],
+
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
@@ -146,9 +179,17 @@
 
     "globals": ["globals@13.24.0", "", { "dependencies": { "type-fest": "^0.20.2" } }, "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -186,9 +227,15 @@
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
@@ -217,6 +264,8 @@
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.5.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -3,3 +3,17 @@ import { Paystack } from "../src";
 const paystack = new Paystack({
    apiKey: process.env.PAYSTACK_API_KEY as string
 })
+
+try {
+   const res = await paystack.transaction.partialDebit({
+      amount: 3000,
+      authorization_code: "AUTH_n4m8jgkqd3",
+      currency: "NGN",
+      email: "customer@email.com"
+   })
+   console.dir(res, { depth: null });
+} catch (error) {
+   if(error instanceof Error) {
+      console.dir(error, { depth: null });
+   }
+}

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   },
   "peerDependencies": {
     "typescript": "^5"
+  },
+  "dependencies": {
+    "axios": "^1.10.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,15 @@
 # @redoxx/paystack
-A developer friendly SDK for Paystack, built with Typescript and Bun.
+
+A developer-friendly SDK for [Paystack](https://paystack.com/docs/api), built with **TypeScript** and powered by **Bun**.
+
+> ⚠️ Currently in early development – breaking changes may occur.
 
 ## Installation
 
 ```bash 
 pnpm add @redoxx/paystack
+# or
+bun add @redoxx/paystack
 ```
 ## Usage
 ```typescript
@@ -19,10 +24,46 @@ const res = await paystack.transaction.initialize({
 
 ```
 
-## Methods
-- transaction.initialize(data)
+## 📦 Available Methods
+- transaction.initialize()
+- transaction.verify()
+- transaction.list()
+- transaction.get()
+- transaction.chargeAuth()
+- transaction.timeLine()
+- transaction.total()
+- transaction.export()
+- transaction.partialDebit()
 
-## Coming Soon
-- transaction.verify(ref)
-- customer.create(data)
-- Webhook signature verification
+## 🧪 Coming Soon
+- ✅ Customer endpoints
+
+- ✅ Webhook signature verification
+
+- 🛠️ Plans, Subscriptions, Terminals, Products
+
+- 🧾 Payment Pages & Requests (low priority)
+
+- 🔍 Verification, Refunds, Disputes, Charges
+
+- 🔁 Integration & Bulk Charges
+
+### 📝 TODO
+- Transaction endpoint still need testing and some return types might not be correct
+- Customer endpoints
+- Plans endpoints
+- Subscription endpoints
+- Terminal endpoints
+- Products endpoints
+- Payment Pages endpoints (low priority)
+- Payment Requests endpoints (low priority)
+- Miscellaneous endpoints
+- Verification endpoints
+- Refunds endpoints
+- Disputes endpoints
+- Charge endpoints (low priority)
+- Integration endpoints
+- Bulk Charges endpoints
+
+#### 🙌 Contributing
+This SDK is currently in active development. Contributions, feedback, and issues are welcome!

--- a/src/modules/transaction.ts
+++ b/src/modules/transaction.ts
@@ -1,0 +1,135 @@
+import type { TRANSACTIONCHARGEAUTH, TRANSACTIONEXPORT, TRANSACTIONINITDATA, TRANSACTIONLISTFILTER, TRANSACTIONPARTIALDEBIT, TRANSACTIONTOTAL } from "../types/transaction";
+import { request } from "../utils/request";
+
+export async function initializeTransaction<T>({
+   apiKey,
+   data
+}: {
+   apiKey: string,
+   data: TRANSACTIONINITDATA
+}
+) {
+   return request<T>({
+      method: "POST",
+      apiKey,
+      path: "/transaction/initialize",
+      data
+   });
+}
+
+export async function verifyTransaction<T>({
+   apiKey,
+   reference
+}: {
+   apiKey: string;
+   reference: string;
+}) {
+   return request<T>({
+      method: "GET",
+      apiKey,
+      path: `/transaction/verify/${reference}`,
+   })
+}
+
+export async function listTransactions<T>({
+   apiKey,
+   filter
+}: {
+   apiKey: string
+   filter?: TRANSACTIONLISTFILTER
+}) {
+   return request<T>({
+      method: "GET",
+      apiKey,
+      path: `/transaction`,
+      data: filter
+   })
+}
+
+export async function getTransaction<T>({
+   apiKey,
+   transactionId
+}: {
+   apiKey: string;
+   transactionId: number
+}) {
+   return request<T>({
+      method: "GET",
+      apiKey,
+      path: `/transaction/${transactionId}`,
+   })
+}
+
+export async function chargeAuth<T>({
+   apiKey,
+   data
+}: {
+   apiKey: string;
+   data: TRANSACTIONCHARGEAUTH
+}) {
+   return request<T>({
+      method: "POST",
+      apiKey,
+      path: "/transaction/charge_authorization",
+      data
+   });
+}
+
+export async function transactionTimeline<T>({
+   apiKey, id, reference
+}: { apiKey: string; id: number; reference?: never }
+   | { apiKey: string; reference: string; id?: never }
+) {
+   const identifier = id ?? reference;
+
+   return request<T>({
+      method: "GET",
+      apiKey,
+      path: `/transaction/timeline/${identifier}`,
+   });
+}
+
+export async function transactionTotal<T>({
+   apiKey,
+   data
+}: {
+   apiKey: string;
+   data?: TRANSACTIONTOTAL
+}) {
+   return request<T>({
+      method: "GET",
+      apiKey,
+      path: `/transaction/totals`,
+      data
+   });
+}
+
+export async function exportTransaction<T>({
+   apiKey,
+   data
+}: {
+   apiKey: string;
+   data?: TRANSACTIONEXPORT
+}) {
+   return request<T>({
+      method: "GET",
+      apiKey,
+      path: `/transaction/export`,
+      data
+   });
+}
+
+export async function transactionPartialDebit<T>({
+   apiKey,
+   data
+}: {
+   apiKey: string;
+   data: TRANSACTIONPARTIALDEBIT
+}) {
+   return request<T>({
+      method: "POST",
+      apiKey,
+      path: `/transaction/partial_debit`,
+      data
+   });
+}

--- a/src/paystack.ts
+++ b/src/paystack.ts
@@ -1,11 +1,64 @@
+import {
+   chargeAuth,
+   exportTransaction,
+   getTransaction,
+   initializeTransaction,
+   listTransactions,
+   transactionPartialDebit,
+   transactionTimeline,
+   transactionTotal,
+   verifyTransaction
+} from "./modules/transaction";
+import {
+   type TRANSACTIONCHARGERESPONSE,
+   type TRANSACTIONCHARGEAUTH,
+   type TRANSACTIONINITDATA,
+   type TRANSACTIONINITRESPONSE,
+   type TRANSACTIONLISTFILTER,
+   type TRANSACTIONLISTRESPONSE,
+   type TRANSACTIONRESPONSE,
+   type TRANSACTIONVERIFICATIONRESPONSE,
+   type TRANSACTIONTIMELINERESPONSE,
+   type TRANSACTIONTOTAL,
+   type TRANSACTIONTOTALSRESPONSE,
+   type TRANSACTIONEXPORT,
+   type TRANSACTIONEXPORTRESPONSE,
+   type TRANSACTIONPARTIALDEBIT,
+   type TRANSACTIONPARTIALDEBITRESPONSE
+} from "./types/transaction";
+
 export class Paystack {
    private apiKey: string
-   
+
    constructor({ apiKey }: { apiKey: string }) {
-      if(apiKey) {
+      if (!apiKey) {
          throw new Error("Paystack API key not found!")
       }
-      
+
       this.apiKey = apiKey
+   }
+
+   transaction = {
+      initialize: (data: TRANSACTIONINITDATA) => initializeTransaction<TRANSACTIONINITRESPONSE | null>({ apiKey: this.apiKey, data }),
+      verify: (reference: string) => verifyTransaction<TRANSACTIONVERIFICATIONRESPONSE | null>({ apiKey: this.apiKey, reference }),
+      list: (filter?: TRANSACTIONLISTFILTER) => listTransactions<TRANSACTIONLISTRESPONSE | null>({ apiKey: this.apiKey, filter }),
+      get: (transactionId: number) => getTransaction<TRANSACTIONRESPONSE | null>({ apiKey: this.apiKey, transactionId }),
+      chargeAuth: (data: TRANSACTIONCHARGEAUTH) => chargeAuth<TRANSACTIONCHARGERESPONSE | null>({ apiKey: this.apiKey, data }),
+      timeLine: (options: { id: number; reference?: never } | { reference: string; id?: never }) => {
+         if (options.id) {
+            return transactionTimeline<TRANSACTIONTIMELINERESPONSE | null>({
+               apiKey: this.apiKey,
+               id: options.id,
+            });
+         } else if (options.reference) {
+            return transactionTimeline<TRANSACTIONTIMELINERESPONSE | null>({
+               apiKey: this.apiKey,
+               reference: options.reference,
+            });
+         }
+      },
+      total: (data?: TRANSACTIONTOTAL) => transactionTotal<TRANSACTIONTOTALSRESPONSE | null>({ apiKey: this.apiKey, data }),
+      export: (data?: TRANSACTIONEXPORT) => exportTransaction<TRANSACTIONEXPORTRESPONSE | null>({ apiKey: this.apiKey, data }),
+      partialDebit: (data: TRANSACTIONPARTIALDEBIT) => transactionPartialDebit<TRANSACTIONPARTIALDEBITRESPONSE | null>({ apiKey: this.apiKey, data })
    }
 }

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -1,0 +1,318 @@
+export interface TRANSACTIONINITDATA {
+   amount: number;
+   email: string;
+   currency?: Currency;
+   reference?: string;
+   callback_url?: string;
+   plan?: string;
+   invoice_limit?: number;
+   metadata?: Record<string, any>,
+   channels?: Channels;
+   split_code?: string;
+   subaccount?: string;
+   transaction_charge?: number;
+   bearer?: string;
+};
+
+export interface TRANSACTIONLISTFILTER {
+   perPage: number;
+   page: number;
+   customer?: number;
+   terminalid?: string;
+   status?: "success" | "failed" | "abandoned";
+   from?: string;
+   to?: string;
+   amount?: number
+};
+
+export interface TRANSACTIONCHARGEAUTH {
+   amount: number;
+   email: string;
+   authorization_code: string;
+   reference?: string;
+   currency?: Currency;
+   metadata?: Record<string, any>;
+   channels?: Channels;
+   subaccount?: string;
+   transaction_charge?: number;
+   bearer?: string;
+   queue?: true
+};
+
+export interface TRANSACTIONTOTAL {
+   perPage: number;
+   page: number;
+   from?: number;
+   to?: number;
+};
+
+export interface TRANSACTIONEXPORT {
+   perPage: number;
+   page: number;
+   from?: number;
+   to?: number;
+   customer?: number;
+   status?: string;
+   currency?: Currency;
+   amount?: number;
+   settled?: boolean;
+   settlement?: number;
+   payment_page?: number;
+};
+
+export interface TRANSACTIONPARTIALDEBIT {
+   authorization_code: string;
+   currency: Currency;
+   amount: number;
+   email: string;
+   reference?: string;
+   at_least?: string;
+}
+
+export interface TRANSACTIONINITRESPONSE {
+   status: boolean;
+   message: string;
+   data: {
+      authorization_url: string,
+      access_code: string,
+      reference: string
+   }
+};
+
+export interface TRANSACTIONVERIFICATIONRESPONSE {
+   status: boolean;
+   message: string;
+   data: PaystackTransaction;
+};
+
+export interface TRANSACTIONLISTRESPONSE {
+   status: boolean;
+   message: string;
+   data: PaystackTransaction[];
+   meta: {
+      total: number,
+      total_volume: number,
+      skipped: number,
+      perPage: number,
+      page: number,
+      pageCount: number
+   };
+};
+
+export interface TRANSACTIONRESPONSE {
+   status: boolean;
+   message: string;
+   data: PaystackTransaction;
+}
+
+export interface TRANSACTIONCHARGERESPONSE {
+   status: boolean;
+   message: string;
+   data: {
+      id: number;
+      amount: number;
+      currency: string;
+      transaction_date: string;
+      status: string;
+      reference: string;
+      domain: string;
+      metadata: any;
+      gateway_response: string;
+      message: string | null;
+      channel: string;
+      ip_address: string | null;
+      log: TransactionLog | null;
+      fees: number;
+      authorization: Authorization;
+      customer: Customer;
+      plan: any;
+   }
+}
+
+export interface TRANSACTIONTIMELINERESPONSE {
+   status: boolean;
+   message: string;
+   data: {
+      start_time: number;
+      time_spent: number;
+      attempts: number;
+      errors: number;
+      success: boolean;
+      mobile: boolean;
+      input: number;
+      history: Array<{
+         type: "action" | "error" | "auth" | "success";
+         message: string;
+         time: number;
+      }>;
+   };
+};
+
+export interface TRANSACTIONTOTALSRESPONSE {
+   status: boolean;
+   message: string;
+   data: {
+      total_transactions: number;
+      total_volume: number;
+      total_volume_by_currency: Array<{
+         currency: string;
+         amount: number;
+      }>;
+      pending_transfers: number;
+      pending_transfers_by_currency: Array<{
+         currency: string;
+         amount: number;
+      }>;
+   };
+};
+
+export type TRANSACTIONEXPORTRESPONSE = {
+   status: boolean;
+   message: string;
+   data: {
+      path: string;
+      expiresAt: string;
+   };
+};
+
+export type TRANSACTIONPARTIALDEBITRESPONSE = {
+   status: boolean;
+   message: string;
+   data: {
+      amount: number;
+      currency: string;
+      transaction_date: string;
+      status: string;
+      reference: string;
+      domain: string;
+      metadata: string | Record<string, any>;
+      gateway_response: string;
+      message: string | null;
+      channel: string;
+      ip_address: string | null;
+      log: TransactionLog | null; 
+      fees: number;
+      authorization: {
+         authorization_code: string;
+         bin: string;
+         last4: string;
+         exp_month: string;
+         exp_year: string;
+         channel: string;
+         card_type: string;
+         bank: string;
+         country_code: string;
+         brand: string;
+         reusable: boolean;
+         signature: string;
+         account_name: string | null;
+      };
+      customer: {
+         id: number;
+         first_name: string | null;
+         last_name: string | null;
+         email: string;
+         customer_code: string;
+         phone: string | null;
+         metadata: {
+            custom_fields?: {
+               display_name: string;
+               variable_name: string;
+               value: string;
+            }[];
+         } | null;
+         risk_action: string;
+         international_format_phone: string | null;
+      };
+      plan: number | null;
+      requested_amount: number;
+      id: number;
+   };
+};
+
+
+export interface PaystackTransaction {
+   id: number;
+   domain: string;
+   status: string;
+   reference: string;
+   receipt_number?: string | null;
+   amount: number;
+   message: string | null;
+   gateway_response: string;
+   paid_at: string | null;
+   created_at: string;
+   channel: Channels[number];
+   currency: string;
+   ip_address: string;
+   metadata: Record<string, any> | string | null;
+   log: TransactionLog | null;
+   fees: number | null;
+   fees_split: Record<string, any> | null;
+   customer: Customer;
+   authorization: Authorization;
+   plan: Record<string, any> | null;
+   split: Record<string, any> | null;
+   subaccount: Record<string, any> | null;
+   order_id: string | null;
+   paidAt: string | null;
+   createdAt: string;
+   requested_amount: number;
+   source: {
+      source: string;
+      type: string;
+      identifier: string | null;
+      entry_point: string;
+   } | null;
+   connect: Record<string, any> | null;
+   pos_transaction_data: Record<string, any> | null;
+   fees_breakdown?: any;
+   transaction_date?: string;
+   plan_object?: Record<string, any>;
+};
+
+export interface TransactionLog {
+   start_time: number;
+   time_spent: number;
+   attempts: number;
+   errors: number;
+   success: boolean;
+   mobile: boolean;
+   input: unknown[];
+   history: {
+      type: string;
+      message: string;
+      time: number;
+   }[];
+}
+
+export interface Authorization {
+   authorization_code: string | null;
+   bin: string | null;
+   last4: string | null;
+   exp_month: string | null;
+   exp_year: string | null;
+   channel: string | null;
+   card_type: string | null;
+   bank: string | null;
+   country_code: string | null;
+   brand: string | null;
+   reusable: boolean;
+   signature: string | null;
+   account_name: string | null;
+}
+
+export interface Customer {
+   id: number;
+   first_name: string | null;
+   last_name: string | null;
+   email: string;
+   customer_code: string;
+   phone: string | null;
+   metadata: Record<string, any> | null;
+   risk_action: string;
+   international_format_phone?: string | null;
+}
+
+export type Channels = ["card", "bank", "apple_pay", "ussd", "qr", "mobile_money", "bank_transfer", "eft"]
+export type Currency = "NGN" | "USD" | "GHS" | "ZAR" | "KES"

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,0 +1,6 @@
+export type RequestOpts = {
+   method: "GET" | "POST" | "PUT" | "DELETE";
+   path: string;
+   apiKey: string;
+   data?: unknown
+}

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,0 +1,23 @@
+import axios, { type AxiosRequestConfig } from "axios";
+import type { RequestOpts } from "../types/utils";
+
+const BASE_URL = "https://api.paystack.co";
+
+export async function request<T>({ apiKey, method, path, data }: RequestOpts): Promise<T> {
+   const config: AxiosRequestConfig = {
+      method,
+      url: `${BASE_URL}${path}`,
+      headers: {
+         Authorization: `Bearer ${apiKey}`,
+         "Content-Type": "application/json",
+      },
+      ...(method === "GET" ? { params: data } : { data }),
+   };
+   
+   try {
+      const res = await axios(config);
+      return res.data;
+   } catch (error) {
+      throw error;
+   }
+}


### PR DESCRIPTION
### Summary

This PR adds the full implementation of Paystack's `/transaction` endpoints, including:
- initialize
- verify
- list
- fetch
- charge authorization
- etc.

✅ Types included  
❗ Needs more testing (see TODOs)  